### PR TITLE
kernel: Set CROSS_COMPILE_ARM32 if using aarch64

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -205,6 +205,11 @@ ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     endif
 endif
 
+# Needed for CONFIG_COMPAT_VDSO, safe to set for all arm64 builds
+ifeq ($(KERNEL_ARCH),arm64)
+   KERNEL_CROSS_COMPILE += CROSS_COMPILE_ARM32="arm-linux-androideabi-"
+endif
+
 ifneq ($(TARGET_KERNEL_MODULES),)
     $(error TARGET_KERNEL_MODULES is no longer supported!)
 endif


### PR DESCRIPTION
Google added a 32-bit vDSO to the Wahoo and Marlin kernels on Android P,
requiring a 32-bit toolchain to compile/link, and the build fails when
it is not provided.

Change-Id: I700e66a417ed431c31d82fc950f5e5acd07ab281